### PR TITLE
Revamp product hero styling to match mock

### DIFF
--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -432,7 +432,7 @@
     text-transform: uppercase;
     letter-spacing: 0.14em;
     font-weight: 700;
-    border-radius: 10px;
+    border-radius: 6px;
     transition: background 0.2s ease, transform 0.2s ease;
   }
   .pdp-scope .atc-button .bg-slide { display: none; }
@@ -452,7 +452,7 @@
     text-transform: uppercase;
     letter-spacing: 0.12em;
     font-weight: 700;
-    border-radius: 10px;
+    border-radius: 6px;
     transition: background 0.2s ease, color 0.2s ease;
   }
   .pdp-scope .buy-now-button:hover { background: #222; }
@@ -505,9 +505,8 @@
   }
   .pdp-scope .quantity-control {
     display: inline-flex;
-    align-items: center;
-    width: auto;
-    min-width: 148px;
+    align-items: stretch;
+    min-width: 156px;
     border-radius: 6px;
     border: 1px solid #cfcfcf;
     overflow: hidden;
@@ -519,7 +518,7 @@
     box-shadow: 0 0 0 1px #111;
   }
   .pdp-scope .qty-btn {
-    flex: 0 0 48px;
+    flex: 1 0 0;
     border: none;
     background: transparent;
     cursor: pointer;
@@ -530,7 +529,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 44px;
+    min-height: 48px;
     transition: background 0.2s ease, color 0.2s ease;
   }
   .pdp-scope .qty-btn:first-of-type {
@@ -550,14 +549,15 @@
     outline-offset: 2px;
   }
   .pdp-scope .qty-display {
-    flex: 1 1 auto;
-    min-width: 46px;
-    display: grid;
-    place-items: center;
-    padding: 0 1.2rem;
+    flex: 1 0 0;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 1rem;
     font-weight: 600;
     letter-spacing: 0.05em;
+    font-variant-numeric: tabular-nums;
     color: #111;
     background: transparent;
   }

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -38,6 +38,14 @@
       <p class="product-label">NEW ARRIVAL</p>
       <h1 class="product-title">CloudNine Hanging Rest Spot</h1>
       <p class="product-price">$19.99</p>
+      <div class="product-meta">
+        <div class="product-meta__rating" aria-label="Rated 4.7 out of 5">
+          <span class="product-meta__stars" aria-hidden="true">★★★★★</span>
+          <span class="product-meta__rating-score">4.7</span>
+        </div>
+        <a class="product-meta__reviews" href="#reviews">1 review</a>
+        <span class="product-meta__sku">SKU: CN-REST-SPOT</span>
+      </div>
 
       <!-- Selling points (with top/bottom dividers) -->
       <div class="sp-block" aria-label="Product highlights">
@@ -71,8 +79,10 @@
         </ul>
       </div>
 
-      <div class="product-rating">★★★★★ <span>(4.7)</span></div>
-      <p class="product-shade" style="display:none;">Shade: <span id="selectedShade"></span></p>
+      <div class="product-color" aria-live="polite">
+        <span class="product-color__label">Color:</span>
+        <span class="product-color__value" id="selectedShade">&mdash;</span>
+      </div>
 
       <!-- COLOR SWATCHES -->
       <div class="swatch-wrapper" id="pdp-swatchWrapper"></div>
@@ -87,11 +97,15 @@
 
           <!-- Quantity (inside the form) -->
           <div class="quantity-wrapper">
-            <button type="button" class="qty-btn" id="pdp-qtyMinus">−</button>
-            <span class="qty-display" id="pdp-qtyValue">1</span>
-            <button type="button" class="qty-btn" id="pdp-qtyPlus">+</button>
+            <div class="quantity-control" role="group" aria-label="Quantity">
+              <button type="button" class="qty-btn" id="pdp-qtyMinus" aria-label="Decrease quantity">−</button>
+              <span class="qty-display" id="pdp-qtyValue" aria-live="polite" aria-atomic="true">1</span>
+              <button type="button" class="qty-btn" id="pdp-qtyPlus" aria-label="Increase quantity">+</button>
+            </div>
             <input type="hidden" name="quantity" value="1" id="pdp-quantityInput"/>
           </div>
+
+          <p class="stock-status">In stock</p>
 
           <add-to-cart-component
             ref="addToCartButtonContainer"
@@ -265,10 +279,92 @@
   .pdp-scope .product-form { flex: 0 0 50%; }
 
   .pdp-scope .product-label { font-size: 0.7rem; color: #999; letter-spacing: 1.2px; margin-bottom: 0.4rem; text-transform: uppercase; }
-  .pdp-scope .product-title { font-family: "Playfair Display", serif; font-size: 2rem; font-weight: 500; margin-bottom: 0.4rem; letter-spacing: 0.5px; }
-  .pdp-scope .product-price { font-size: 1.3rem;margin-top: 0;  font-weight: 400; margin-bottom: 0.95rem; }
-  .pdp-scope .product-rating { font-size: 0.95rem; margin-bottom: 0.7rem; }
-  .pdp-scope .product-rating span { color: #aaa; margin-left: 0.25em; }
+  .pdp-scope .product-title {
+    font-family: 'Inter', sans-serif;
+    font-size: 2.35rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.35rem;
+  }
+  .pdp-scope .product-price {
+    font-size: 1.6rem;
+    font-weight: 600;
+    margin: 0 0 1.1rem;
+    letter-spacing: 0.04em;
+  }
+  .pdp-scope .product-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.9rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.88rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .pdp-scope .product-meta__rating {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: #a06b07;
+  }
+  .pdp-scope .product-meta__stars {
+    font-size: 1rem;
+    letter-spacing: 0.3em;
+  }
+  .pdp-scope .product-meta__rating-score {
+    font-size: 0.9rem;
+    color: #111;
+  }
+  .pdp-scope .product-meta__reviews {
+    font-weight: 600;
+    color: #111;
+    text-decoration: none;
+    position: relative;
+  }
+  .pdp-scope .product-meta__reviews::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -0.2rem;
+    width: 100%;
+    height: 1px;
+    background: currentColor;
+    transform-origin: left;
+    transition: transform 0.2s ease;
+  }
+  .pdp-scope .product-meta__reviews:hover::after,
+  .pdp-scope .product-meta__reviews:focus-visible::after {
+    transform: scaleX(0);
+  }
+  .pdp-scope .product-meta__reviews:focus-visible {
+    outline: 2px solid #111;
+    outline-offset: 3px;
+  }
+  .pdp-scope .product-meta__sku {
+    font-weight: 500;
+    color: #555;
+  }
+  .pdp-scope .product-color {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.7rem;
+    font-size: 0.92rem;
+  }
+  .pdp-scope .product-color__label {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #888;
+    font-size: 0.78rem;
+  }
+  .pdp-scope .product-color__value {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
   /* Selling points block with top/bottom dividers */
   .pdp-scope .sp-block{
     border-top:1px solid #e3e3e3;
@@ -312,7 +408,6 @@
     70%{transform:scale(2.2);opacity:0}
     100%{transform:scale(1);opacity:0}
   }
-  .pdp-scope .product-shade { font-size: 0.85rem; margin-bottom: 0.5rem; }
   .pdp-scope .product-description {
     font-size: 0.9rem;
     line-height: 1.4;
@@ -321,19 +416,101 @@
     color: #555;
   }
 
-  .pdp-scope .atc-button { background: #fff; color: #111; border: 1px solid #111; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; margin-bottom: 0.5rem; transition: all 0.3s ease; }
-  .pdp-scope .atc-button:hover { background: #111; color: #fff; }
-  .pdp-scope .buy-now-button { background: #111; color: #fff; border: none; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; transition: background 0.3s ease; }
-  .pdp-scope .buy-now-button:hover { background: #333; }
+  .pdp-scope .atc-button {
+    position: relative;
+    overflow: hidden;
+    background: #f7e32c;
+    color: #111;
+    border: none;
+    padding: 1rem 1.5rem;
+    font-size: 1rem;
+    width: 100%;
+    margin-bottom: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-weight: 700;
+    border-radius: 999px;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+  .pdp-scope .atc-button .bg-slide { display: none; }
+  .pdp-scope .atc-button:hover { background: #e7d30f; transform: translateY(-1px); }
+  .pdp-scope .atc-button:active { transform: translateY(0); }
+  .pdp-scope .atc-button:focus-visible {
+    outline: 3px solid #111;
+    outline-offset: 3px;
+  }
+  .pdp-scope .buy-now-button {
+    background: #111;
+    color: #fff;
+    border: 1px solid #111;
+    padding: 1rem 1.5rem;
+    font-size: 1rem;
+    width: 100%;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    border-radius: 999px;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+  .pdp-scope .buy-now-button:hover { background: #222; }
+  .pdp-scope .buy-now-button:focus-visible {
+    outline: 3px solid #111;
+    outline-offset: 3px;
+  }
   .pdp-scope .add-to-cart-error { color: #c62828; font-size: .9rem; margin:.5rem 0 1rem; }
 
-  .pdp-scope .swatch-wrapper { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 1.1rem; }
-  .pdp-scope .swatch { width: 26px; height: 26px; cursor: pointer; }
+  .pdp-scope .swatch-wrapper { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 1.2rem; }
+  .pdp-scope .swatch { width: 28px; height: 28px; cursor: pointer; border-radius: 50%; border: 1px solid transparent; transition: transform 0.2s ease; }
   .pdp-scope .swatch.selected { outline: 1px solid #111; outline-offset: 2px; }
+  .pdp-scope .swatch:hover { transform: translateY(-1px); }
 
-  .pdp-scope .quantity-wrapper { display: flex; align-items: center; gap: 1rem; margin-bottom: 1.1rem; margin-top: 0.3rem; }
-  .pdp-scope .qty-btn { width: 38px; height: 30px; border: 1px solid #ccc; background: #fff; cursor: pointer; font-size: 1.05rem; }
-  .pdp-scope .qty-display { font-size: 0.98rem; }
+  .pdp-scope .quantity-wrapper {
+    margin: 1.2rem 0 0.75rem;
+  }
+  .pdp-scope .quantity-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid #111;
+    background: #f9f9f9;
+  }
+  .pdp-scope .qty-btn {
+    width: 42px;
+    height: 42px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 1.4rem;
+    line-height: 1;
+    font-weight: 600;
+    color: #111;
+    border-radius: 999px;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+  .pdp-scope .qty-btn:hover { background: rgba(0, 0, 0, 0.06); }
+  .pdp-scope .qty-btn:focus-visible {
+    outline: 2px solid #111;
+    outline-offset: 2px;
+  }
+  .pdp-scope .qty-display {
+    min-width: 34px;
+    text-align: center;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: #111;
+  }
+
+  .pdp-scope .stock-status {
+    margin: 0 0 1.4rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #0e8a55;
+  }
 
   /* Accordion compact style */
   .pdp-scope .product-details-accordion { margin-top: 1.5rem; }
@@ -584,6 +761,7 @@
     const mobileImageStrip = pdpRoot.querySelector('#pdp-mobileImageStrip');
     const addToCartComponent = pdpRoot.querySelector('#pdp-addToCartComponent');
     const variantIdInput = pdpRoot.querySelector('#pdp-variantIdInput');
+    const selectedShade = pdpRoot.querySelector('#selectedShade');
 
     const zoom = createZoomLightbox(pdpRoot);
     let currentVariantImages = [];
@@ -673,6 +851,9 @@
       }
       if (variantIdInput) {
         variantIdInput.value = variant.id;
+      }
+      if (selectedShade) {
+        selectedShade.textContent = variant.title;
       }
       currentVariantImages = normalizeVariantImages(variant);
       currentImageIndex = 0;

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -97,7 +97,8 @@
 
           <!-- Quantity (inside the form) -->
           <div class="quantity-wrapper">
-            <div class="quantity-control" role="group" aria-label="Quantity">
+            <label class="quantity-label" id="pdp-quantityLabel" for="pdp-quantityInput">Quantity:</label>
+            <div class="quantity-control" role="group" aria-labelledby="pdp-quantityLabel">
               <button type="button" class="qty-btn" id="pdp-qtyMinus" aria-label="Decrease quantity">−</button>
               <span class="qty-display" id="pdp-qtyValue" aria-live="polite" aria-atomic="true">1</span>
               <button type="button" class="qty-btn" id="pdp-qtyPlus" aria-label="Increase quantity">+</button>
@@ -491,60 +492,74 @@
   }
 
   .pdp-scope .quantity-wrapper {
-    margin: 1.4rem 0 0.85rem;
+    margin: 1.4rem 0 1rem;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+  .pdp-scope .quantity-label {
+    font-size: 0.92rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: #2b2b2b;
   }
   .pdp-scope .quantity-control {
     display: inline-flex;
-    align-items: stretch;
-    width: 100%;
-    max-width: 260px;
-    border-radius: 12px;
-    border: 1px solid #1a1a1a;
+    align-items: center;
+    width: auto;
+    min-width: 148px;
+    border-radius: 6px;
+    border: 1px solid #cfcfcf;
     overflow: hidden;
     background: #fff;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  }
+  .pdp-scope .quantity-control:focus-within {
+    border-color: #111;
+    box-shadow: 0 0 0 1px #111;
   }
   .pdp-scope .qty-btn {
-    flex: 1 1 33%;
-    min-width: 0;
+    flex: 0 0 48px;
     border: none;
     background: transparent;
     cursor: pointer;
-    font-size: 1.35rem;
+    font-size: 1.2rem;
     line-height: 1;
     font-weight: 600;
     color: #111;
     display: flex;
     align-items: center;
     justify-content: center;
+    min-height: 44px;
     transition: background 0.2s ease, color 0.2s ease;
   }
   .pdp-scope .qty-btn:first-of-type {
-    border-right: 1px solid #e3e3e3;
+    border-right: 1px solid #e2e2e2;
   }
   .pdp-scope .qty-btn:last-of-type {
-    border-left: 1px solid #e3e3e3;
+    border-left: 1px solid #e2e2e2;
   }
   .pdp-scope .qty-btn:hover {
-    background: #f5f5f5;
+    background: #f6f6f6;
   }
   .pdp-scope .qty-btn:active {
-    background: #e8e8e8;
+    background: #eaeaea;
   }
   .pdp-scope .qty-btn:focus-visible {
     outline: 2px solid #111;
     outline-offset: 2px;
   }
   .pdp-scope .qty-display {
-    flex: 1 1 34%;
-    min-width: 0;
+    flex: 1 1 auto;
+    min-width: 46px;
     display: grid;
     place-items: center;
-    padding: 0 0.5rem;
+    padding: 0 1.2rem;
     font-size: 1rem;
     font-weight: 600;
     letter-spacing: 0.05em;
     color: #111;
-    background: #fafafa;
+    background: transparent;
   }
 
   .pdp-scope .stock-status {

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -299,6 +299,8 @@
     align-items: center;
     gap: 0.9rem;
     margin-bottom: 1.25rem;
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid #e3e3e3;
     font-size: 0.88rem;
     letter-spacing: 0.04em;
     text-transform: uppercase;
@@ -351,7 +353,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    margin-bottom: 0.7rem;
+    margin: 1.2rem 0 0.75rem;
     font-size: 0.92rem;
   }
   .pdp-scope .product-color__label {
@@ -422,14 +424,14 @@
     background: #f7e32c;
     color: #111;
     border: none;
-    padding: 1rem 1.5rem;
+    padding: 0.85rem 1.25rem;
     font-size: 1rem;
     width: 100%;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.4rem;
     text-transform: uppercase;
     letter-spacing: 0.14em;
     font-weight: 700;
-    border-radius: 999px;
+    border-radius: 10px;
     transition: background 0.2s ease, transform 0.2s ease;
   }
   .pdp-scope .atc-button .bg-slide { display: none; }
@@ -443,13 +445,13 @@
     background: #111;
     color: #fff;
     border: 1px solid #111;
-    padding: 1rem 1.5rem;
+    padding: 0.85rem 1.25rem;
     font-size: 1rem;
     width: 100%;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     font-weight: 700;
-    border-radius: 999px;
+    border-radius: 10px;
     transition: background 0.2s ease, color 0.2s ease;
   }
   .pdp-scope .buy-now-button:hover { background: #222; }
@@ -459,48 +461,90 @@
   }
   .pdp-scope .add-to-cart-error { color: #c62828; font-size: .9rem; margin:.5rem 0 1rem; }
 
-  .pdp-scope .swatch-wrapper { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 1.2rem; }
-  .pdp-scope .swatch { width: 28px; height: 28px; cursor: pointer; border-radius: 50%; border: 1px solid transparent; transition: transform 0.2s ease; }
-  .pdp-scope .swatch.selected { outline: 1px solid #111; outline-offset: 2px; }
-  .pdp-scope .swatch:hover { transform: translateY(-1px); }
+  .pdp-scope .swatch-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+  }
+  .pdp-scope .swatch {
+    width: 38px;
+    height: 38px;
+    cursor: pointer;
+    border-radius: 8px;
+    border: 1px solid #dcdcdc;
+    background-clip: padding-box;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  }
+  .pdp-scope .swatch:hover,
+  .pdp-scope .swatch:focus-visible {
+    transform: translateY(-1px);
+    border-color: #b5b5b5;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+    outline: none;
+  }
+  .pdp-scope .swatch.selected {
+    border-width: 2px;
+    border-color: #111;
+    box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.08);
+  }
 
   .pdp-scope .quantity-wrapper {
-    margin: 1.2rem 0 0.75rem;
+    margin: 1.4rem 0 0.85rem;
   }
   .pdp-scope .quantity-control {
     display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.5rem 0.75rem;
-    border-radius: 999px;
-    border: 1px solid #111;
-    background: #f9f9f9;
+    align-items: stretch;
+    width: 100%;
+    max-width: 260px;
+    border-radius: 12px;
+    border: 1px solid #1a1a1a;
+    overflow: hidden;
+    background: #fff;
   }
   .pdp-scope .qty-btn {
-    width: 42px;
-    height: 42px;
+    flex: 1 1 33%;
+    min-width: 0;
     border: none;
     background: transparent;
     cursor: pointer;
-    font-size: 1.4rem;
+    font-size: 1.35rem;
     line-height: 1;
     font-weight: 600;
     color: #111;
-    border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: background 0.2s ease, color 0.2s ease;
   }
-  .pdp-scope .qty-btn:hover { background: rgba(0, 0, 0, 0.06); }
+  .pdp-scope .qty-btn:first-of-type {
+    border-right: 1px solid #e3e3e3;
+  }
+  .pdp-scope .qty-btn:last-of-type {
+    border-left: 1px solid #e3e3e3;
+  }
+  .pdp-scope .qty-btn:hover {
+    background: #f5f5f5;
+  }
+  .pdp-scope .qty-btn:active {
+    background: #e8e8e8;
+  }
   .pdp-scope .qty-btn:focus-visible {
     outline: 2px solid #111;
     outline-offset: 2px;
   }
   .pdp-scope .qty-display {
-    min-width: 34px;
-    text-align: center;
+    flex: 1 1 34%;
+    min-width: 0;
+    display: grid;
+    place-items: center;
+    padding: 0 0.5rem;
     font-size: 1rem;
     font-weight: 600;
     letter-spacing: 0.05em;
     color: #111;
+    background: #fafafa;
   }
 
   .pdp-scope .stock-status {


### PR DESCRIPTION
## Summary
- update the product hero to use the mock’s uppercase Inter heading, expanded price styling, and new metadata row
- expose the color label above the swatches and wire it to variant selection while refreshing the swatch and quantity visuals
- restyle the add-to-cart and buy-now buttons and insert the in-stock status banner to reflect the latest CTA system

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d367aeaa64832fbb17a2f73124f1a8