### PR TITLE
Align product form styling with demo

### DIFF
--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -39,9 +39,25 @@
       <h1 class="product-title">CloudNine Hanging Rest Spot</h1>
       <p class="product-price">$19.99</p>
 
-      <div class="product-meta">
-        <div class="meta-stars" aria-label="Rating: 4.7 out of 5">★★★★★</div>
-        <a href="#reviews" class="meta-link">4 reviews</a>
+      <div class="product-meta" aria-label="Product rating and review count">
+        <div class="meta-stars" role="img" aria-label="Rating: 4.7 out of 5">
+          <svg class="meta-star" viewBox="0 -0.5 32 32" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16.0005 0L21.4392 9.27275L32.0005 11.5439L24.8005 19.5459L25.889 30.2222L16.0005 25.895L6.11194 30.2222L7.20049 19.5459L0.000488281 11.5439L10.5618 9.27275L16.0005 0Z" />
+          </svg>
+          <svg class="meta-star" viewBox="0 -0.5 32 32" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16.0005 0L21.4392 9.27275L32.0005 11.5439L24.8005 19.5459L25.889 30.2222L16.0005 25.895L6.11194 30.2222L7.20049 19.5459L0.000488281 11.5439L10.5618 9.27275L16.0005 0Z" />
+          </svg>
+          <svg class="meta-star" viewBox="0 -0.5 32 32" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16.0005 0L21.4392 9.27275L32.0005 11.5439L24.8005 19.5459L25.889 30.2222L16.0005 25.895L6.11194 30.2222L7.20049 19.5459L0.000488281 11.5439L10.5618 9.27275L16.0005 0Z" />
+          </svg>
+          <svg class="meta-star" viewBox="0 -0.5 32 32" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16.0005 0L21.4392 9.27275L32.0005 11.5439L24.8005 19.5459L25.889 30.2222L16.0005 25.895L6.11194 30.2222L7.20049 19.5459L0.000488281 11.5439L10.5618 9.27275L16.0005 0Z" />
+          </svg>
+          <svg class="meta-star" viewBox="0 -0.5 32 32" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16.0005 0L21.4392 9.27275L32.0005 11.5439L24.8005 19.5459L25.889 30.2222L16.0005 25.895L6.11194 30.2222L7.20049 19.5459L0.000488281 11.5439L10.5618 9.27275L16.0005 0Z" />
+          </svg>
+        </div>
+        <span class="meta-count" aria-label="4 reviews">(4)</span>
       </div>
 
       <!-- Selling points (with top/bottom dividers) -->
@@ -324,23 +340,28 @@
   .pdp-scope .product-meta {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
     font-size: 0.875rem;
     color: var(--pdp-muted);
     margin-bottom: 1.1rem;
   }
   .pdp-scope .meta-stars {
-    color: var(--pdp-star);
-    font-size: 1.25rem;
-    letter-spacing: 0.2em;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
-  .pdp-scope .meta-link {
-    color: inherit;
-    text-decoration: underline;
+  .pdp-scope .meta-star {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
   }
-  .pdp-scope .meta-link:focus-visible,
-  .pdp-scope .meta-link:hover {
-    color: var(--pdp-fg);
+  .pdp-scope .meta-star path {
+    fill: var(--pdp-star);
+  }
+  .pdp-scope .meta-count {
+    color: var(--pdp-muted);
+    font-weight: 600;
+    letter-spacing: 0.02em;
   }
   /* Selling points block with top/bottom dividers */
   .pdp-scope .sp-block{

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -261,12 +261,13 @@
     --pdp-muted: #6b7280;
     --pdp-star: #f5a623;
     --pdp-border: #d1d5db;
+    --pdp-border-hover: #4b5563;
     --pdp-border-strong: #0B0D10;
     --pdp-btn-primary: #F2FF2A;
     --pdp-btn-primary-fg: #0B0D10;
     --pdp-btn-secondary: #405DE6;
     --pdp-btn-secondary-fg: #ffffff;
-    --pdp-swatch-size: 40px;
+    --pdp-swatch-size: 36px;
     font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
     color: var(--pdp-fg);
     line-height: 1.5;
@@ -464,7 +465,7 @@
     transition: border-color 0.2s ease;
   }
   .pdp-scope .swatch:hover {
-    border-color: var(--pdp-border-strong);
+    border-color: var(--pdp-border-hover);
   }
   .pdp-scope .swatch:focus-visible {
     outline: 2px solid var(--pdp-border-strong);

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -42,8 +42,6 @@
       <div class="product-meta">
         <div class="meta-stars" aria-label="Rating: 4.7 out of 5">★★★★★</div>
         <a href="#reviews" class="meta-link">4 reviews</a>
-        <span class="meta-spacer"></span>
-        <div class="product-sku">SKU: CLOUD-REST-SPOT</div>
       </div>
 
       <!-- Selling points (with top/bottom dividers) -->
@@ -342,12 +340,6 @@
   .pdp-scope .meta-link:focus-visible,
   .pdp-scope .meta-link:hover {
     color: var(--pdp-fg);
-  }
-  .pdp-scope .meta-spacer { flex: 1 1 auto; }
-  .pdp-scope .product-sku {
-    font-size: 0.8125rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
   }
   /* Selling points block with top/bottom dividers */
   .pdp-scope .sp-block{

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -324,7 +324,7 @@
   }
   .pdp-scope .meta-stars {
     color: var(--pdp-star);
-    font-size: 1.125rem;
+    font-size: 1.25rem;
     letter-spacing: 0.2em;
   }
   .pdp-scope .meta-link {
@@ -461,10 +461,10 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    transition: border-color 0.2s ease, transform 0.2s ease;
+    transition: border-color 0.2s ease;
   }
   .pdp-scope .swatch:hover {
-    transform: translateY(-2px);
+    border-color: var(--pdp-border-strong);
   }
   .pdp-scope .swatch:focus-visible {
     outline: 2px solid var(--pdp-border-strong);

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -351,8 +351,8 @@
     gap: 6px;
   }
   .pdp-scope .meta-star {
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1em;
+    height: 1em;
     display: block;
   }
   .pdp-scope .meta-star path {

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -293,7 +293,6 @@
   .pdp-scope .mobile-image-strip { display: none; }
   .pdp-scope .product-form {
     flex: 1 1 50%;
-    max-width: 420px;
   }
 
   .pdp-scope .product-label {

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -1,6 +1,6 @@
 <!-- ====== HEAD (fonts + theme globals) ====== -->
 <link rel="preconnect" href="https://fonts.gstatic.com">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Playfair+Display:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Rubik:wght@400;500;700&family=Tomorrow:wght@400;700;900&display=swap" rel="stylesheet">
 
 <!-- Theme globals required by product-form.js -->
 <script>
@@ -39,6 +39,15 @@
       <h1 class="product-title">CloudNine Hanging Rest Spot</h1>
       <p class="product-price">$19.99</p>
 
+      <div class="product-meta">
+        <div class="meta-stars" aria-label="Rating: 4.7 out of 5">★★★★★</div>
+        <a href="#reviews" class="meta-link">4 reviews</a>
+        <span class="meta-spacer"></span>
+        <div class="product-sku">SKU: CLOUD-REST-SPOT</div>
+      </div>
+
+      <div class="product-divider"></div>
+
       <!-- Selling points (with top/bottom dividers) -->
       <div class="sp-block" aria-label="Product highlights">
         <ul class="sp-list">
@@ -71,11 +80,10 @@
         </ul>
       </div>
 
-      <div class="product-rating">★★★★★ <span>(4.7)</span></div>
-      <p class="product-shade" style="display:none;">Shade: <span id="selectedShade"></span></p>
+      <p class="product-option-label" id="pdp-colorLabel">Color: <span id="selectedShade">Blue</span></p>
 
       <!-- COLOR SWATCHES -->
-      <div class="swatch-wrapper" id="pdp-swatchWrapper"></div>
+      <div class="swatch-wrapper" id="pdp-swatchWrapper" role="radiogroup" aria-labelledby="pdp-colorLabel"></div>
 
       <p class="product-description">
         The ultimate chill zone for comfort-loving cats—CloudNine™ gives them a front-row seat to the outside world while soaking up the sun. Watch them stretch, lounge, and snooze as elevated views ease anxiety and satisfy their inner observer. Minimal, secure, and irresistibly cozy—your cat’s new favorite spot starts here.
@@ -86,39 +94,42 @@
           <input type="hidden" name="id" value="" ref="variantId" id="pdp-variantIdInput"/>
 
           <!-- Quantity (inside the form) -->
-          <div class="quantity-wrapper">
-            <button type="button" class="qty-btn" id="pdp-qtyMinus">−</button>
-            <span class="qty-display" id="pdp-qtyValue">1</span>
-            <button type="button" class="qty-btn" id="pdp-qtyPlus">+</button>
+          <p class="product-option-label">Quantity:</p>
+          <div class="quantity-wrapper" role="group" aria-label="Choose quantity">
+            <button type="button" class="qty-btn" id="pdp-qtyMinus" aria-label="Decrease quantity">−</button>
+            <span class="qty-display" id="pdp-qtyValue" aria-live="polite" aria-atomic="true">1</span>
+            <button type="button" class="qty-btn" id="pdp-qtyPlus" aria-label="Increase quantity">+</button>
             <input type="hidden" name="quantity" value="1" id="pdp-quantityInput"/>
           </div>
 
-          <add-to-cart-component
-            ref="addToCartButtonContainer"
-            id="pdp-addToCartComponent"
-            data-product-variant-media=""
-            data-add-to-cart-animation="true">
-            <button
-              type="submit"
-              ref="addToCartButton"
-              class="atc-button"
-              onclick="
-                this.closest('add-to-cart-component').handleClick(event);
-                this.closest('product-form-component').handleSubmit(event);
-              "
-              aria-label="Add this item to your cart">
-              <span class="bg-slide"></span>
-              <span class="label">ADD TO CART</span>
-            </button>
-          </add-to-cart-component>
+          <div class="cta">
+            <add-to-cart-component
+              ref="addToCartButtonContainer"
+              id="pdp-addToCartComponent"
+              data-product-variant-media=""
+              data-add-to-cart-animation="true">
+              <button
+                type="submit"
+                ref="addToCartButton"
+                class="atc-button"
+                onclick="
+                  this.closest('add-to-cart-component').handleClick(event);
+                  this.closest('product-form-component').handleSubmit(event);
+                "
+                aria-label="Add this item to your cart">
+                <span class="bg-slide"></span>
+                <span class="label">ADD TO CART</span>
+              </button>
+            </add-to-cart-component>
+
+            <button type="button" class="buy-now-button">BUY IT NOW</button>
+          </div>
 
           <!-- Error container used by product-form.js -->
           <p ref="addToCartTextError" class="add-to-cart-error hidden" aria-live="polite"></p>
 
           <!-- Optional accelerated checkout block (toggles hidden/unhidden by product-form.js) -->
           <div ref="acceleratedCheckoutButtonContainer" hidden></div>
-
-          <button type="button" class="buy-now-button">BUY IT NOW</button>
           <div ref="liveRegion" class="visually-hidden" aria-live="polite"></div>
         </form>
       </product-form-component>
@@ -241,9 +252,27 @@
     overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
   }
 
-  .pdp-scope body { font-family: 'Inter', sans-serif; }
+  .pdp-scope {
+    --pdp-fg: #282828;
+    --pdp-muted: #6b7280;
+    --pdp-star: #f5a623;
+    --pdp-border: #d1d5db;
+    --pdp-border-strong: #0B0D10;
+    --pdp-btn-primary: #F2FF2A;
+    --pdp-btn-primary-fg: #0B0D10;
+    --pdp-btn-secondary: #405DE6;
+    --pdp-btn-secondary-fg: #ffffff;
+    --pdp-swatch-size: 40px;
+    font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    color: var(--pdp-fg);
+    line-height: 1.5;
+  }
   .pdp-scope .product-wrapper {
-    display: flex; gap: 2rem; max-width: 1400px; margin: 0 auto; padding: 2rem 3rem;
+    display: flex;
+    gap: 3rem;
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 2.5rem 3rem;
     align-items: flex-start;
   }
   .pdp-scope .product-image { flex: 0 0 50%; display: flex; gap: 1rem; position: relative; align-items: flex-start; }
@@ -262,13 +291,64 @@
     outline-offset: 2px;
   }
   .pdp-scope .mobile-image-strip { display: none; }
-  .pdp-scope .product-form { flex: 0 0 50%; }
+  .pdp-scope .product-form {
+    flex: 1 1 50%;
+    max-width: 420px;
+  }
 
-  .pdp-scope .product-label { font-size: 0.7rem; color: #999; letter-spacing: 1.2px; margin-bottom: 0.4rem; text-transform: uppercase; }
-  .pdp-scope .product-title { font-family: "Playfair Display", serif; font-size: 2rem; font-weight: 500; margin-bottom: 0.4rem; letter-spacing: 0.5px; }
-  .pdp-scope .product-price { font-size: 1.3rem;margin-top: 0;  font-weight: 400; margin-bottom: 0.95rem; }
-  .pdp-scope .product-rating { font-size: 0.95rem; margin-bottom: 0.7rem; }
-  .pdp-scope .product-rating span { color: #aaa; margin-left: 0.25em; }
+  .pdp-scope .product-label {
+    font-size: 0.75rem;
+    color: var(--pdp-muted);
+    letter-spacing: 0.24em;
+    margin-bottom: 0.6rem;
+    text-transform: uppercase;
+  }
+  .pdp-scope .product-title {
+    font-family: 'Tomorrow', 'Inter', sans-serif;
+    font-weight: 900;
+    font-size: 2.5rem;
+    line-height: 1.1;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    margin: 0 0 1.2rem;
+  }
+  .pdp-scope .product-price {
+    font: 500 22px/1.2 'Rubik', 'Inter', sans-serif;
+    color: var(--pdp-fg);
+    margin: 0 0 0.9rem;
+  }
+  .pdp-scope .product-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.875rem;
+    color: var(--pdp-muted);
+    margin-bottom: 1.1rem;
+  }
+  .pdp-scope .meta-stars {
+    color: var(--pdp-star);
+    font-size: 1.125rem;
+    letter-spacing: 0.2em;
+  }
+  .pdp-scope .meta-link {
+    color: inherit;
+    text-decoration: underline;
+  }
+  .pdp-scope .meta-link:focus-visible,
+  .pdp-scope .meta-link:hover {
+    color: var(--pdp-fg);
+  }
+  .pdp-scope .meta-spacer { flex: 1 1 auto; }
+  .pdp-scope .product-sku {
+    font-size: 0.8125rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .pdp-scope .product-divider {
+    height: 1px;
+    background: #eee;
+    margin-bottom: 1.5rem;
+  }
   /* Selling points block with top/bottom dividers */
   .pdp-scope .sp-block{
     border-top:1px solid #e3e3e3;
@@ -314,26 +394,125 @@
   }
   .pdp-scope .product-shade { font-size: 0.85rem; margin-bottom: 0.5rem; }
   .pdp-scope .product-description {
-    font-size: 0.9rem;
-    line-height: 1.4;
-    margin-bottom: 1.2rem;
-    font-weight: 300;
-    color: #555;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin-bottom: 1.6rem;
+    font-weight: 400;
+    color: #4b5563;
   }
 
-  .pdp-scope .atc-button { background: #fff; color: #111; border: 1px solid #111; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; margin-bottom: 0.5rem; transition: all 0.3s ease; }
-  .pdp-scope .atc-button:hover { background: #111; color: #fff; }
-  .pdp-scope .buy-now-button { background: #111; color: #fff; border: none; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; transition: background 0.3s ease; }
-  .pdp-scope .buy-now-button:hover { background: #333; }
-  .pdp-scope .add-to-cart-error { color: #c62828; font-size: .9rem; margin:.5rem 0 1rem; }
+  .pdp-scope .cta {
+    display: grid;
+    gap: 14px;
+    margin-top: 1.2rem;
+  }
+  .pdp-scope .cta add-to-cart-component { display: block; }
+  .pdp-scope .atc-button,
+  .pdp-scope .buy-now-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 52px;
+    border-radius: 0;
+    border: 0;
+    cursor: pointer;
+    font: 700 14px/1 'Inter', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0 35px;
+    transition: transform 0.12s ease, box-shadow 0.2s ease;
+  }
+  .pdp-scope .atc-button {
+    background: var(--pdp-btn-primary);
+    color: var(--pdp-btn-primary-fg);
+    box-shadow: none;
+    position: relative;
+    overflow: hidden;
+  }
+  .pdp-scope .atc-button:hover { transform: translateY(-1px); }
+  .pdp-scope .atc-button:focus-visible,
+  .pdp-scope .buy-now-button:focus-visible {
+    outline: 2px solid var(--pdp-border-strong);
+    outline-offset: 2px;
+  }
+  .pdp-scope .atc-button .bg-slide { display: none; }
+  .pdp-scope .buy-now-button {
+    background: var(--pdp-btn-secondary);
+    color: var(--pdp-btn-secondary-fg);
+  }
+  .pdp-scope .buy-now-button:hover { background: #2f4edb; }
+  .pdp-scope .add-to-cart-error {
+    color: #c62828;
+    font-size: 0.875rem;
+    margin: 0.75rem 0 0;
+  }
 
-  .pdp-scope .swatch-wrapper { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 1.1rem; }
-  .pdp-scope .swatch { width: 26px; height: 26px; cursor: pointer; }
-  .pdp-scope .swatch.selected { outline: 1px solid #111; outline-offset: 2px; }
+  .pdp-scope .product-option-label {
+    display: block;
+    font-weight: 600;
+    margin: 1.4rem 0 0.75rem;
+    letter-spacing: 0.02em;
+  }
+  .pdp-scope .swatch-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 1.6rem;
+  }
+  .pdp-scope .swatch {
+    width: var(--pdp-swatch-size);
+    height: var(--pdp-swatch-size);
+    border: 2px solid var(--pdp-border);
+    border-radius: 0;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+  .pdp-scope .swatch:hover {
+    transform: translateY(-2px);
+  }
+  .pdp-scope .swatch:focus-visible {
+    outline: 2px solid var(--pdp-border-strong);
+    outline-offset: 2px;
+  }
+  .pdp-scope .swatch.selected {
+    border-color: var(--pdp-border-strong);
+  }
 
-  .pdp-scope .quantity-wrapper { display: flex; align-items: center; gap: 1rem; margin-bottom: 1.1rem; margin-top: 0.3rem; }
-  .pdp-scope .qty-btn { width: 38px; height: 30px; border: 1px solid #ccc; background: #fff; cursor: pointer; font-size: 1.05rem; }
-  .pdp-scope .qty-display { font-size: 0.98rem; }
+  .pdp-scope .quantity-wrapper {
+    display: grid;
+    grid-template-columns: 48px 72px 48px;
+    border: 1px solid var(--pdp-border);
+    background: #fff;
+    margin: 0 0 1.6rem;
+    width: fit-content;
+  }
+  .pdp-scope .qty-btn {
+    width: 100%;
+    height: 44px;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--pdp-fg);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .pdp-scope .qty-btn:focus-visible {
+    outline: 2px solid var(--pdp-border-strong);
+    outline-offset: -2px;
+  }
+  .pdp-scope .qty-display {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: 600 16px/1 'Inter', sans-serif;
+  }
 
   /* Accordion compact style */
   .pdp-scope .product-details-accordion { margin-top: 1.5rem; }
@@ -363,9 +542,13 @@
   @media (min-width: 1024px) {
     .pdp-scope .product-image { position: sticky; top: 88px; }
   }
+  @media (max-width: 560px) {
+    .pdp-scope .product-title { font-size: 2.125rem; }
+  }
   @media (max-width: 768px) {
     .pdp-scope .product-wrapper { flex-direction: column; padding: 1rem; gap: 0; }
     .pdp-scope .product-image, .pdp-scope .product-form { width: 100%; }
+    .pdp-scope .product-form { max-width: 100%; }
     .pdp-scope .product-thumbnails, .pdp-scope #pdp-mainProductImage { display: none !important; }
     .pdp-scope .mobile-image-strip {
       display: flex; flex-direction: row; overflow-x: auto; gap: 1rem;
@@ -584,6 +767,7 @@
     const mobileImageStrip = pdpRoot.querySelector('#pdp-mobileImageStrip');
     const addToCartComponent = pdpRoot.querySelector('#pdp-addToCartComponent');
     const variantIdInput = pdpRoot.querySelector('#pdp-variantIdInput');
+    const selectedShade = pdpRoot.querySelector('#selectedShade');
 
     const zoom = createZoomLightbox(pdpRoot);
     let currentVariantImages = [];
@@ -668,11 +852,17 @@
       }
       if (swatchWrapper) {
         swatchWrapper.querySelectorAll('.swatch').forEach((swatch, i) => {
-          swatch.classList.toggle('selected', i === index);
+          const isActive = i === index;
+          swatch.classList.toggle('selected', isActive);
+          swatch.setAttribute('aria-checked', isActive ? 'true' : 'false');
+          swatch.tabIndex = isActive ? 0 : -1;
         });
       }
       if (variantIdInput) {
         variantIdInput.value = variant.id;
+      }
+      if (selectedShade) {
+        selectedShade.textContent = variant.title;
       }
       currentVariantImages = normalizeVariantImages(variant);
       currentImageIndex = 0;
@@ -698,12 +888,27 @@
         sw.style.backgroundColor = variant.color;
         sw.title = variant.title;
         sw.dataset.variantId = variant.id;
-        sw.tabIndex = 0;
+        sw.setAttribute('role', 'radio');
+        sw.setAttribute('aria-label', variant.title);
+        sw.setAttribute('aria-checked', idx === 0 ? 'true' : 'false');
+        sw.tabIndex = idx === 0 ? 0 : -1;
         sw.addEventListener('click', () => selectVariant(idx));
         sw.addEventListener('keydown', (event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             selectVariant(idx);
+          } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+            event.preventDefault();
+            const nextIndex = (idx + 1) % VARIANTS.length;
+            selectVariant(nextIndex);
+            const swatches = swatchWrapper?.querySelectorAll('.swatch');
+            swatches?.[nextIndex]?.focus();
+          } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            const prevIndex = (idx - 1 + VARIANTS.length) % VARIANTS.length;
+            selectVariant(prevIndex);
+            const swatches = swatchWrapper?.querySelectorAll('.swatch');
+            swatches?.[prevIndex]?.focus();
           }
         });
         swatchWrapper.appendChild(sw);

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -261,7 +261,7 @@
     --pdp-muted: #6b7280;
     --pdp-star: #f5a623;
     --pdp-border: #d1d5db;
-    --pdp-border-hover: #4b5563;
+    --pdp-border-hover: #9ca3af;
     --pdp-border-strong: #0B0D10;
     --pdp-btn-primary: #F2FF2A;
     --pdp-btn-primary-fg: #0B0D10;

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -83,10 +83,6 @@
       <!-- COLOR SWATCHES -->
       <div class="swatch-wrapper" id="pdp-swatchWrapper" role="radiogroup" aria-labelledby="pdp-colorLabel"></div>
 
-      <p class="product-description">
-        The ultimate chill zone for comfort-loving cats—CloudNine™ gives them a front-row seat to the outside world while soaking up the sun. Watch them stretch, lounge, and snooze as elevated views ease anxiety and satisfy their inner observer. Minimal, secure, and irresistibly cozy—your cat’s new favorite spot starts here.
-      </p>
-
       <product-form-component data-product-id="7770300416118" data-url="{{ routes.cart_add_url }}">
         <form id="pdp-form" method="post">
           <input type="hidden" name="id" value="" ref="variantId" id="pdp-variantIdInput"/>
@@ -137,10 +133,22 @@
         <section class="accordion-section" aria-label="Product details">
           <div class="accordion">
             <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-1" id="acc-trigger-1">
-              <span>Shipping</span>
+              <span>Description</span>
               <span class="accordion-icon">+</span>
             </button>
             <div class="accordion-body" id="acc-panel-1" role="region" aria-labelledby="acc-trigger-1">
+              <div class="accordion-content">
+                <p>The ultimate chill zone for comfort-loving cats—CloudNine™ gives them a front-row seat to the outside world while soaking up the sun. Watch them stretch, lounge, and snooze as elevated views ease anxiety and satisfy their inner observer. Minimal, secure, and irresistibly cozy—your cat’s new favorite spot starts here.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="accordion">
+            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-2" id="acc-trigger-2">
+              <span>Shipping</span>
+              <span class="accordion-icon">+</span>
+            </button>
+            <div class="accordion-body" id="acc-panel-2" role="region" aria-labelledby="acc-trigger-2">
               <div class="accordion-content">
                 <p>For orders placed before 7am AEDT, we endeavour to process the same business day. Orders placed after 11am AEDT will be processed the next business day.</p>
                 <p>During sale events and new collection launches, there may be a slightly longer processing time.</p>
@@ -150,11 +158,11 @@
           </div>
 
           <div class="accordion">
-            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-2" id="acc-trigger-2">
+            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-3" id="acc-trigger-3">
               <span>Returns</span>
               <span class="accordion-icon">+</span>
             </button>
-            <div class="accordion-body" id="acc-panel-2" role="region" aria-labelledby="acc-trigger-2">
+            <div class="accordion-body" id="acc-panel-3" role="region" aria-labelledby="acc-trigger-3">
               <div class="accordion-content">
                 <p>You can choose between a refund or a credit note on full-priced items.</p>
                 <ul>
@@ -168,11 +176,11 @@
           </div>
 
           <div class="accordion">
-            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-3" id="acc-trigger-3">
+            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-4" id="acc-trigger-4">
               <span>Fabric &amp; Care</span>
               <span class="accordion-icon">+</span>
             </button>
-            <div class="accordion-body" id="acc-panel-3" role="region" aria-labelledby="acc-trigger-3">
+            <div class="accordion-body" id="acc-panel-4" role="region" aria-labelledby="acc-trigger-4">
               <div class="accordion-content">
                 <p>Composition: 98% Cotton, 2% Elastane. Soft hand-feel with light stretch.</p>
                 <ul>
@@ -186,11 +194,11 @@
           </div>
 
           <div class="accordion">
-            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-4" id="acc-trigger-4">
+            <button class="accordion-header" type="button" aria-expanded="false" aria-controls="acc-panel-5" id="acc-trigger-5">
               <span>Size &amp; Fit</span>
               <span class="accordion-icon">+</span>
             </button>
-            <div class="accordion-body" id="acc-panel-4" role="region" aria-labelledby="acc-trigger-4">
+            <div class="accordion-body" id="acc-panel-5" role="region" aria-labelledby="acc-trigger-5">
               <div class="accordion-content">
                 <p>Fits true to size. Peplum hem hits at the high hip; square neckline.</p>
                 <ul>

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -22,7 +22,14 @@
       <div class="product-thumbnails" id="pdp-productThumbnails"></div>
       <img
         id="pdp-mainProductImage"
-        src=""
+        src="https://cdn.shopify.com/s/files/1/0623/9718/6166/files/Sbfd9b49d5eb548c9bb90a8dfa8b675c9Z.webp?v=1754469861&width=1200"
+        srcset="https://cdn.shopify.com/s/files/1/0623/9718/6166/files/Sbfd9b49d5eb548c9bb90a8dfa8b675c9Z.webp?v=1754469861&width=480 480w, https://cdn.shopify.com/s/files/1/0623/9718/6166/files/Sbfd9b49d5eb548c9bb90a8dfa8b675c9Z.webp?v=1754469861&width=720 720w, https://cdn.shopify.com/s/files/1/0623/9718/6166/files/Sbfd9b49d5eb548c9bb90a8dfa8b675c9Z.webp?v=1754469861&width=960 960w, https://cdn.shopify.com/s/files/1/0623/9718/6166/files/Sbfd9b49d5eb548c9bb90a8dfa8b675c9Z.webp?v=1754469861&width=1200 1200w, https://cdn.shopify.com/s/files/1/0623/9718/6166/files/Sbfd9b49d5eb548c9bb90a8dfa8b675c9Z.webp?v=1754469861&width=1500 1500w"
+        sizes="(min-width: 1024px) 50vw, 100vw"
+        width="1200"
+        height="1500"
+        loading="eager"
+        decoding="async"
+        fetchpriority="high"
         alt="Product image"
         role="button"
         tabindex="0"
@@ -775,6 +782,36 @@
       }
     ];
 
+    const RESPONSIVE_WIDTHS = [480, 720, 960, 1200, 1500];
+    const MAIN_IMAGE_SIZES = '(min-width: 1024px) 50vw, 100vw';
+    const THUMB_WIDTH = 320;
+    const MOBILE_STRIP_WIDTH = 960;
+
+    const createSizedSrc = (src, width) => {
+      try {
+        const url = new URL(src);
+        url.searchParams.set('width', String(width));
+        return url.toString();
+      } catch (error) {
+        return src;
+      }
+    };
+
+    const buildSrcSet = (src) => RESPONSIVE_WIDTHS
+      .map((width) => `${createSizedSrc(src, width)} ${width}w`)
+      .join(', ');
+
+    const applyMainImageSources = (imageEl, originalSrc) => {
+      if (!imageEl || !originalSrc) {
+        return;
+      }
+      const preferredWidth = RESPONSIVE_WIDTHS[RESPONSIVE_WIDTHS.length - 2]; // 1200w
+      imageEl.src = createSizedSrc(originalSrc, preferredWidth);
+      imageEl.srcset = buildSrcSet(originalSrc);
+      imageEl.sizes = MAIN_IMAGE_SIZES;
+      imageEl.dataset.fullSrc = originalSrc;
+    };
+
     const swatchWrapper = pdpRoot.querySelector('#pdp-swatchWrapper');
     const thumbsDiv = pdpRoot.querySelector('#pdp-productThumbnails');
     const mainImage = pdpRoot.querySelector('#pdp-mainProductImage');
@@ -802,7 +839,7 @@
       currentImageIndex = index;
       const item = currentVariantImages[index];
       if (mainImage) {
-        mainImage.src = item.src;
+        applyMainImageSources(mainImage, item.src);
         mainImage.alt = item.alt || mainImageBaseAlt;
       }
       if (addToCartComponent) {
@@ -825,7 +862,7 @@
       images.forEach((image, i) => {
         const thumb = document.createElement('img');
         thumb.className = 'thumbnail' + (i === currentImageIndex ? ' active' : '');
-        thumb.src = image.src;
+        thumb.src = createSizedSrc(image.src, THUMB_WIDTH);
         thumb.alt = image.alt || `Thumbnail ${i + 1}`;
         thumb.loading = i === 0 ? 'eager' : 'lazy';
         thumb.decoding = 'async';
@@ -845,7 +882,7 @@
       mobileImageStrip.innerHTML = '';
       images.forEach((image, i) => {
         const img = document.createElement('img');
-        img.src = image.src;
+        img.src = createSizedSrc(image.src, MOBILE_STRIP_WIDTH);
         img.loading = i === 0 ? 'eager' : 'lazy';
         img.decoding = 'async';
         img.draggable = false;

--- a/snippets/product-description.liquid
+++ b/snippets/product-description.liquid
@@ -46,8 +46,6 @@
         <div class="product-sku">SKU: CLOUD-REST-SPOT</div>
       </div>
 
-      <div class="product-divider"></div>
-
       <!-- Selling points (with top/bottom dividers) -->
       <div class="sp-block" aria-label="Product highlights">
         <ul class="sp-list">
@@ -270,7 +268,7 @@
   .pdp-scope .product-wrapper {
     display: flex;
     gap: 3rem;
-    max-width: 1040px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 2.5rem 3rem;
     align-items: flex-start;
@@ -342,11 +340,6 @@
     font-size: 0.8125rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-  }
-  .pdp-scope .product-divider {
-    height: 1px;
-    background: #eee;
-    margin-bottom: 1.5rem;
   }
   /* Selling points block with top/bottom dividers */
   .pdp-scope .sp-block{


### PR DESCRIPTION
## Summary
- update the product form markup and typography to match the demo layout, including the meta row, swatch label, and CTA grouping
- refresh the PDP styles with Tomorrow/Rubik/Inter fonts, square swatches, grid-based quantity stepper, and responsive tweaks
- enhance swatch accessibility by syncing the visible color name, radiogroup semantics, and keyboard navigation

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3dd090c6c832fb938eb9eec4dc2b7